### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/deploy-kinto.py
+++ b/deploy-kinto.py
@@ -52,7 +52,7 @@ cliquet.http_scheme = https
 cliquet.http_host = https://%(id_alwaysdata)s.alwaysdata.net/
 
 cliquet.project_name = kinto
-cliquet.project_docs = https://kinto.readthedocs.org/
+cliquet.project_docs = https://kinto.readthedocs.io/
 
 #
 # Backends.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
